### PR TITLE
Potential fix for code scanning alert no. 31: Information exposure through an exception

### DIFF
--- a/configs/iot/app.py
+++ b/configs/iot/app.py
@@ -12,7 +12,7 @@ from flask import Flask, jsonify, request
 from flask_wtf.csrf import CSRFProtect
 from flask_cors import CORS
 import requests
-
+import traceback
 app = Flask(__name__)
 
 # Configure CSRF protection
@@ -190,9 +190,10 @@ def communicate_with_services():
             'timestamp': datetime.utcnow().isoformat()
         })
     except Exception as e:
+        app.logger.error("Exception in /api/system/communicate: %s\n%s", e, traceback.format_exc())
         return jsonify({
             'error': 'Communication failed',
-            'details': str(e),
+            'details': 'Internal server error',
             'timestamp': datetime.utcnow().isoformat()
         }), 500
 


### PR DESCRIPTION
Potential fix for [https://github.com/LegitWIZRD/servicepi/security/code-scanning/31](https://github.com/LegitWIZRD/servicepi/security/code-scanning/31)

The best way to fix this problem is to ensure that exception details (such as `str(e)`) are never returned in the HTTP response to an API client. Instead, send a generic error message to clients while optionally logging the full exception details or stack trace server-side using the `logging` module or Flask's `app.logger`. This preserves useful diagnostic information for developers and operators without risking information disclosure to users. 

Specifically:
- In the exception handler (lines 192-197), replace `'details': str(e)` with a generic message such as `'details': 'Internal server error'`.
- Add a `logging` statement (or `app.logger.error`) to record the exception details and stack trace on the server.
- Import the `traceback` and/or `logging` modules if needed, but only if shown in the snippet.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
